### PR TITLE
fix: make this work on stable rustc

### DIFF
--- a/stylers/Cargo.toml
+++ b/stylers/Cargo.toml
@@ -14,4 +14,4 @@ proc_macro = true
 
 [dependencies]
 quote = "1.0"
-proc-macro2 = { version = "1.0" }
+proc-macro2 = { version = "1.0", features = ["span-locations"] }

--- a/stylers/src/lib.rs
+++ b/stylers/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_span)]
-#![feature(extend_one)]
 //! This crate provides style macro for scoped css in rust web frameworks which follows component like architecture e.g Leptos.
 mod style;
 mod style_sheet;

--- a/stylers/src/style/css_style_rule.rs
+++ b/stylers/src/style/css_style_rule.rs
@@ -69,7 +69,7 @@ impl CSSStyleRule {
                             if ch == '.' || ch == '#' {
                                 add_spaces(&mut selector, t.span(), &mut pre_line, &mut pre_col);
                             } else {
-                                let end = t.span().unwrap().end();
+                                let end = t.span().end();
                                 pre_col = end.column;
                                 pre_line = end.line;
                             }

--- a/stylers/src/style/css_style_sheet.rs
+++ b/stylers/src/style/css_style_sheet.rs
@@ -32,7 +32,7 @@ impl CSSStyleSheet {
         loop {
             if let Some(tt) = ts_iter.next() {
                 count += 1;
-                css_rule_tt.extend_one(tt.clone());
+                css_rule_tt.extend(Some(tt.clone()));
                 match tt {
                     TokenTree::Group(t) => {
                         if t.delimiter() == Delimiter::Brace {

--- a/stylers/src/style/utils.rs
+++ b/stylers/src/style/utils.rs
@@ -55,8 +55,8 @@ pub(crate) fn add_spaces(
     pre_line: &mut usize,
     pre_col: &mut usize,
 ) {
-    let start = span.unwrap().start();
-    let end = span.unwrap().end();
+    let start = span.start();
+    let end = span.end();
     let cur_col = start.column;
     let cur_line = start.line;
     if *pre_line == cur_line && cur_col > *pre_col {


### PR DESCRIPTION
`get`: We're using proc_macro2 already so I don't see any harm in using it's implemenation for that.

`extend_one`: The nightly implemenation just calls `extend(Some(x))` anyway so there's no use in  using it until it's actually stable.