### PR TITLE
feat: adding :deep directive in selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["stylers", "stylers_test"]
 exclude = ["examples"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```cargo add stylers```
 
 ## Leptos Example
-### style!
+#### style!
 ```rust
 #[component]
 fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
@@ -48,7 +48,7 @@ fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
     }
 }
 ```
-### style_sheet!
+#### style_sheet!
 ```rust
 #[component]
 fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
@@ -63,7 +63,7 @@ fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
 ```
 - In this case you should place the ```hello.css``` file inside the `root` directory of the project.
 
-### style_str!
+#### style_str!
 - Note that in `style_str!` macro we don't need to pass the component name as we do in `style!` macro.
 ```rust
 #[component]
@@ -107,7 +107,7 @@ pub fn GreenButton(cx: Scope) -> impl IntoView {
 }
 ```
 
-### style_sheet_str!
+#### style_sheet_str!
 ```rust
 #[component]
 pub fn BlueButton(cx: Scope) -> impl IntoView {
@@ -120,6 +120,31 @@ pub fn BlueButton(cx: Scope) -> impl IntoView {
 }
 ```
 - In this case you should place the ```button.css``` file inside the `src` directory of the project.
+
+## Custom pseudo classes
+- In some situations we may need our css to affect `deep down` the dom tree. To achieve this we have custom pseudo class called `:deep()`. For example below css is valid one.
+#### Input
+```css
+div :deep(h3) {
+    color: orange;
+}
+```
+#### Output
+```css
+div.l-243433 h3{color: orange;}
+```
+
+- If you want your particular css to be `global` you can use `:deep()` directive without any selector preceding it.
+#### Input
+```css
+:deep(h3 div) {
+    color: orange;
+}
+```
+#### Ouput
+```css
+h3 div{color: orange;}
+```
 
 ## How it works:
 

--- a/examples/style/Cargo.lock
+++ b/examples/style/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/style/src/lib.rs
+++ b/examples/style/src/lib.rs
@@ -54,8 +54,8 @@ fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
 #[component]
 pub fn Abi(cx: Scope) -> impl IntoView {
     let class_name = style! {"Abi",
-        h3{
-            background-color: yellow;
+        div :deep(h3){
+            color: orange;
         }
         @media only screen and (max-width: 1000px) {
             h3 {
@@ -65,7 +65,9 @@ pub fn Abi(cx: Scope) -> impl IntoView {
         }
     };
     view! {cx, class = class_name,
-        <Hello name="hello"/>
-        <h3 >"Hai"</h3>
+        <div>
+            <Hello name="hello"/>
+            <h3 >"Hai"</h3>
+        </div>
     }
 }

--- a/examples/style/src/lib.rs
+++ b/examples/style/src/lib.rs
@@ -54,6 +54,7 @@ fn Hello(cx: Scope, name: &'static str) -> impl IntoView {
 #[component]
 pub fn Abi(cx: Scope) -> impl IntoView {
     let class_name = style! {"Abi",
+        // we can use this :deep() pseudo class in external css file as well.
         div :deep(h3){
             color: orange;
         }

--- a/examples/style_modularized/Cargo.lock
+++ b/examples/style_modularized/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/style_parent_child/Cargo.lock
+++ b/examples/style_parent_child/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/style_sheet/Cargo.lock
+++ b/examples/style_sheet/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/style_sheet_str/Cargo.lock
+++ b/examples/style_sheet_str/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/style_str/Cargo.lock
+++ b/examples/style_str/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "stylers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/stylers/src/style/css_style_rule.rs
+++ b/stylers/src/style/css_style_rule.rs
@@ -148,9 +148,13 @@ impl CSSStyleRule {
             if is_deep_directive && c != '(' {
                 continue;
             }
-            if c == ':' && source.ends_with(' ') {
-                is_deep_directive = true;
-                continue;
+            if c == ':' {
+                if let Some(sub) = selector_text.get(i..i + 4) {
+                    if sub == "deep" {
+                        is_deep_directive = true;
+                        continue;
+                    }
+                }
             }
 
             //ignore everything until we reach to whitespace or end of the line after encountering pseudo class selector(:).

--- a/stylers_test/src/style_sheet_test.rs
+++ b/stylers_test/src/style_sheet_test.rs
@@ -39,4 +39,11 @@ pub fn run_tests() {
         style.trim(),
         r#"@page {size: A4;margin: 10%;@top-left-corner {content: "Page " counter(page);}}@font-face {font-family: "Trickster";src: local("Trickster"),url("trickster-COLRv1.otf") format("opentype") tech(color-COLRv1), url("trickster-outline.otf") format("opentype"), url("trickster-outline.woff") format("woff");}@keyframes spin1 {to {-webkit-transform: rotate(360deg);}}@-webkit-keyframes spin2 {to {-webkit-transform: rotate(360deg);}}@counter-style thumbs {system: cyclic;symbols: "\1F44D";suffix: " ";}@font-feature-values Font One {@styleset {nice-style: 12;}}@property --property-name {syntax: "<color>";inherits: false;initial-value: #c0ffee;}"#
     );
+
+    println!("--------------Custom Pseudo Class Tests------------");
+    let style = style_sheet_test!("./stylers_test/src/test_css_files/custom_pseudo.css");
+    assert_eq!(
+        style.trim(),
+        r#"h3 div{color: orange;}div.test h3{color: orange;}div.test>h3{color: orange;}"#
+    );
 }

--- a/stylers_test/src/style_test.rs
+++ b/stylers_test/src/style_test.rs
@@ -467,4 +467,12 @@ pub fn run_tests() {
         style.trim(),
         "#container.test{--first-color: #290;}#thirdParagraph.test{background-color: var(--first-color);color: var(--second-color);}"
     );
+
+    println!("------------------Test-44-----------------");
+    let style = style_test! {"Hello",
+        div :deep(h3) {
+            color: orange;
+        }
+    };
+    assert_eq!(style.trim(), "div.test h3{color: orange;}");
 }

--- a/stylers_test/src/style_test.rs
+++ b/stylers_test/src/style_test.rs
@@ -468,6 +468,7 @@ pub fn run_tests() {
         "#container.test{--first-color: #290;}#thirdParagraph.test{background-color: var(--first-color);color: var(--second-color);}"
     );
 
+    // Custom pseudo class.
     println!("------------------Test-44-----------------");
     let style = style_test! {"Hello",
         div :deep(h3) {
@@ -475,4 +476,20 @@ pub fn run_tests() {
         }
     };
     assert_eq!(style.trim(), "div.test h3{color: orange;}");
+
+    println!("------------------Test-45-----------------");
+    let style = style_test! {"Hello",
+        :deep(h3 div) {
+            color: orange;
+        }
+    };
+    assert_eq!(style.trim(), "h3 div{color: orange;}");
+
+    println!("------------------Test-44-----------------");
+    let style = style_test! {"Hello",
+        div> :deep(h3) {
+            color: orange;
+        }
+    };
+    assert_eq!(style.trim(), "div.test>h3{color: orange;}");
 }

--- a/stylers_test/src/test_css_files/custom_pseudo.css
+++ b/stylers_test/src/test_css_files/custom_pseudo.css
@@ -1,0 +1,11 @@
+:deep(h3 div) {
+    color: orange;
+}
+
+div :deep(h3) {
+    color: orange;
+}
+
+div>:deep(h3) {
+    color: orange;
+}


### PR DESCRIPTION
To close [this issue](https://github.com/abishekatp/stylers/issues/19) I have added `:deep()` directive in the selectors. In this implementation :deep() should alwauy be used followed by some other selectors.