### PR TITLE
fix: whitespace before punctuation

### DIFF
--- a/stylers/src/style/css_style_rule.rs
+++ b/stylers/src/style/css_style_rule.rs
@@ -192,7 +192,14 @@ impl CSSStyleRule {
                 }
             }
             if c == ',' || c == '+' || c == '~' || c == '>' || c == '|' {
-                source.push_str(random_class);
+                // The end of source is not a whitespace, push random_class
+                if let Some(ch) = source.chars().rev().next() {
+                    if !ch.is_whitespace() {
+                        source.push_str(random_class);
+                    } else {
+                        source = source.trim_end().to_string();
+                    }
+                }
                 source.push(c);
                 is_punct_start = true;
 

--- a/stylers_test/src/style_sheet_test.rs
+++ b/stylers_test/src/style_sheet_test.rs
@@ -44,6 +44,6 @@ pub fn run_tests() {
     let style = style_sheet_test!("./stylers_test/src/test_css_files/custom_pseudo.css");
     assert_eq!(
         style.trim(),
-        r#"h3 div{color: orange;}div.test h3{color: orange;}div.test>h3{color: orange;}"#
+        r#"h3 div{color: orange;}div.test h3{color: orange;}div.test>h3{color: orange;}div.test>h3{color: orange;}"#
     );
 }

--- a/stylers_test/src/style_test.rs
+++ b/stylers_test/src/style_test.rs
@@ -502,6 +502,9 @@ pub fn run_tests() {
         div> :deep(h3) {
             color: orange;
         }
+        div > :deep(h3) {
+            color: orange;
+        }
     };
-    assert_eq!(style.trim(), "div.test>h3{color: orange;}");
+    assert_eq!(style.trim(), "div.test>h3{color: orange;}div.test>h3{color: orange;}");
 }

--- a/stylers_test/src/test_css_files/custom_pseudo.css
+++ b/stylers_test/src/test_css_files/custom_pseudo.css
@@ -9,3 +9,7 @@ div :deep(h3) {
 div>:deep(h3) {
     color: orange;
 }
+
+div >:deep(h3) {
+    color: orange;
+}


### PR DESCRIPTION
```css
div >:deep(h3) {
    color: orange;
}
```
error render:
```css
div.test .test>h3{color: orange;}
```
should be:
```css
div.test>h3{color: orange;}
```
