### PR TITLE
fix: support [attribute] selector with :deep directive

### DIFF
--- a/stylers/src/style/css_style_rule.rs
+++ b/stylers/src/style/css_style_rule.rs
@@ -112,7 +112,10 @@ impl CSSStyleRule {
                 if c == ']' {
                     is_bracket_open = false;
                     source.push(c);
-                    source.push_str(random_class);
+                    
+                    if !is_deep_directive_open {
+                       source.push_str(random_class);
+                    }
 
                     temp.push(c);
                     sel_map.insert(temp.clone(), ());

--- a/stylers_test/src/style_test.rs
+++ b/stylers_test/src/style_test.rs
@@ -504,4 +504,21 @@ pub fn run_tests() {
         }
     };
     assert_eq!(style.trim(), "div.test>h3{color: orange;}");
+
+
+    println!("------------------Test-48-----------------");
+    let style = style_test! {"Hello",
+        :deep([data-custom]) {
+            color: orange;
+        }
+    };
+    assert_eq!(style.trim(), "[data-custom]{color: orange;}");
+
+    println!("------------------Test-49-----------------");
+    let style = style_test! {"Hello",
+        .nested> :deep([data-custom]) {
+            color: orange;
+        }
+    };
+    assert_eq!(style.trim(), ".nested.test>[data-custom]{color: orange;}");
 }


### PR DESCRIPTION
Fixes #27 in which the `:deep` directive will still emit code with the scoped/random class when a `[attribute]` selector is used.
