### PR TITLE
fix double -webkit- being valid in validation

### DIFF
--- a/stylers_core/src/style/css_style_declar.rs
+++ b/stylers_core/src/style/css_style_declar.rs
@@ -680,7 +680,7 @@ impl StyleDeclaration {
 }
 
 fn validate_property(prop_key: &str, prop_map: &HashMap<&str, ()>) -> (bool, Option<String>) {
-    let property = prop_key.trim_start_matches("-webkit-");
+    let property = prop_key.strip_prefix("-webkit-").unwrap_or(prop_key);
     if prop_map.contains_key(property) {
         return (true, None);
     } else if property.starts_with("--") {


### PR DESCRIPTION
Fixed when typed for example -webkit-webkit-position being valid css code. trim_start_matches matches multiple times and deletes all of the matches. Since typing more than one -webkit- is invalid css I changed it to strip_prefix which only matches once